### PR TITLE
feat: automatically format copyright string in footer with current year

### DIFF
--- a/docs_overrides/hooks/year.py
+++ b/docs_overrides/hooks/year.py
@@ -1,0 +1,4 @@
+from datetime import datetime
+def on_config(config, **kwargs):
+    year: str = str(datetime.now().year)
+    config.copyright = config.copyright.format(year=year)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,9 @@ edit_uri: blob/main/docs/
 extra_css:
 - assets/css/extra.css
 
+hooks:
+- docs_overrides/hooks/year.py
+
 theme:
   language: en
   name: material

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -109,7 +109,7 @@ extra:
     repo_issue: https://github.com/silverhack/monkey365/issues
     repo_discussion: https://github.com/silverhack/monkey365/discussions
     
-copyright: Copyright &copy; 2023 <a href="https://twitter.com/tr1ana" target="blank">Juan Garrido</a>
+copyright: Copyright &copy; {year} <a href="https://twitter.com/tr1ana" target="blank">Juan Garrido</a>
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
### Context 

Currently the docs use a hardcoded year in the footer, this PR automatically inserts the current year.


### Description
Method shared by @kamilkrzyskow in this discussion: [How to add the year automatically in the copyright part](https://github.com/squidfunk/mkdocs-material/discussions/4969#discussioncomment-13027051)


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
