### PR TITLE
fix: updated filepath to sample-report

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,7 +83,7 @@ nav:
   - License and Contributing: license/license-contributing.md
   - Support: support/support.md
   - Disclaimer: support/disclaimer.md
-  - Sample Report: sample/monkey365.html
+  - Sample Report: sample/Monkey365.html
 
 extra:
   consent:


### PR DESCRIPTION
### Context 

Mentioned in #147:

>... after having a quick look around I've noticed a bug in the nav/file name. Unix paths are case sensitive, so the sample page doesn't load, as the file name in the nav/the file itself isn't correct. ...
> 
> https://github.com/silverhack/monkey365/blob/a057d2bf47ff3da8c66f6189ec5c18823fd067af/mkdocs.yml#L86
> 
> https://silverhack.github.io/monkey365/sample/monkey365.html
> https://silverhack.github.io/monkey365/sample/Monkey365.html
> 




### Description

PR fixes the link. Thank you @kamilkrzyskow ❤️ 


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
